### PR TITLE
Fix dataset indices bug

### DIFF
--- a/ultralytics/utils/tlc/engine/dataset.py
+++ b/ultralytics/utils/tlc/engine/dataset.py
@@ -31,7 +31,8 @@ class TLCDatasetMixin:
 
     def resample_indices(self):
         # Sample from available indices
-        self._indices[:] = np.random.choice(self.example_ids, len(self.example_ids), p=self._sample_probabilities)
+        indices = np.arange(len(self.example_ids))
+        self._indices[:] = np.random.choice(indices, len(indices), p=self._sample_probabilities)
 
     def __getitem__(self, index):
         i = self._indices[index]

--- a/ultralytics/utils/tlc/engine/dataset.py
+++ b/ultralytics/utils/tlc/engine/dataset.py
@@ -17,10 +17,10 @@ class TLCDatasetMixin:
             raise ValueError("Cannot use sampling weights with no sample weight column in the table.")
 
         assert hasattr(self, "table") and isinstance(self.table, tlc.Table), "TLCDatasetMixin requires an attribute `table` which is a tlc.Table."
-        # Assume instance has self._indices (live sampled indices of the dataset)
         # Assume instance has self._example_ids (index -> example_id mapping)
 
         if not hasattr(self, "_indices"):
+            # Sequentially iterate over the samples by default
             self._indices = np.arange(len(self.example_ids))
 
         sample_weights = [


### PR DESCRIPTION
Fix a bug where when using sampling weights or excluding zero weights, example indices were incorrectly used as sample indices into the dataset.