### PR TITLE
Add settings check to collection only

### DIFF
--- a/ultralytics/utils/tlc/engine/model.py
+++ b/ultralytics/utils/tlc/engine/model.py
@@ -64,6 +64,8 @@ class TLCYOLO(YOLO):
         if settings is None:
             settings = Settings()
 
+        settings.verify(training=False)
+
         results_dict = {}
         # Call val for each split or table
         if data and splits:

--- a/ultralytics/utils/tlc/settings.py
+++ b/ultralytics/utils/tlc/settings.py
@@ -146,7 +146,7 @@ class Settings:
             f'Invalid collection epoch interval {self.collection_epoch_interval}.')
 
     def _verify_collection(self) -> None:
-        """ Verify that the settings are valid for metrics collection only (val.py --task collect).
+        """ Verify that the settings are valid for metrics collection only (no training).
 
         :raises: AssertionError if the settings are invalid.
         """


### PR DESCRIPTION
User-provided `Settings` instances are verified for training, but not when used for metrics collection only. This PR adds such a call when using `model.collect(...)`. This way any invalid settings or missing reducer dependencies are flagged before a run is started.