### PR TITLE
Move handling of zero weights back to dataset for collection

### DIFF
--- a/tests/test_3lc.py
+++ b/tests/test_3lc.py
@@ -268,7 +268,7 @@ def test_sampling_weights() -> None:
     assert len(sampled_example_ids) == len(edited_table) * epochs, "Expected no change in the number of samples"
 
 
-def test_exclude_zero_weight() -> None:
+def test_exclude_zero_weight_training() -> None:
     # Test that sampling weights are correctly applied, with worker processes enabled
     settings = Settings(project_name="test_sampling_weights", exclude_zero_weight_training=True)
     trainer = TLCDetectionTrainer(overrides={"data": TASK2DATASET["detect"], "settings": settings, "workers": 4})

--- a/tests/test_3lc.py
+++ b/tests/test_3lc.py
@@ -270,7 +270,7 @@ def test_sampling_weights() -> None:
 
 def test_exclude_zero_weight_training() -> None:
     # Test that sampling weights are correctly applied, with worker processes enabled
-    settings = Settings(project_name="test_sampling_weights", exclude_zero_weight_training=True)
+    settings = Settings(project_name="test_exclude_zero_weight_training", exclude_zero_weight_training=True)
     trainer = TLCDetectionTrainer(overrides={"data": TASK2DATASET["detect"], "settings": settings, "workers": 4})
 
     # Create edited table where one sample has weight increased to 2
@@ -303,7 +303,7 @@ def test_exclude_zero_weight_collection(task, trainer_class) -> None:
 
     # Create edited table where several samples have weight 0
     edited_table = tlc.EditedTable(
-        url=trainer.trainset.url.create_sibling("erna"),
+        url=trainer.trainset.url.create_sibling(f"erna_{task}"),
         input_table_url=trainer.trainset,
         edits={tlc.SAMPLE_WEIGHT: {
             "runs_and_values": [[0, 3], 0.0]}},

--- a/tests/test_3lc.py
+++ b/tests/test_3lc.py
@@ -294,7 +294,7 @@ def test_exclude_zero_weight() -> None:
                                                 ("classify", TLCClassificationTrainer)])
 def test_exclude_zero_weight_collection(task, trainer_class) -> None:
     # Test that sampling weights are correctly applied during metrics collection
-    settings = Settings(project_name="test_sampling_weights_collection", exclude_zero_weight_collection=True)
+    settings = Settings(project_name=f"test_sampling_weights_collection_{task}", exclude_zero_weight_collection=True)
     trainer = trainer_class(overrides={"data": TASK2DATASET[task], "settings": settings, "workers": 2})
 
     # Classification trainer needs a model object to create dataloader

--- a/tests/test_3lc.py
+++ b/tests/test_3lc.py
@@ -290,7 +290,7 @@ def test_exclude_zero_weight() -> None:
 
 def test_exclude_zero_weight_collection() -> None:
     # Test that sampling weights are correctly applied during metrics collection
-    settings = Settings(project_name="test_sampling_weights", exclude_zero_weight_collection=True)
+    settings = Settings(project_name="test_sampling_weights_collection", exclude_zero_weight_collection=True)
     trainer = TLCDetectionTrainer(overrides={"data": TASK2DATASET["detect"], "settings": settings, "workers": 2})
 
     # Create edited table where several samples have weight 0

--- a/ultralytics/utils/tlc/classify/dataset.py
+++ b/ultralytics/utils/tlc/classify/dataset.py
@@ -33,6 +33,7 @@ class TLCClassificationDataset(TLCDatasetMixin, ClassificationDataset):
         prefix="",
         image_column_name=tlc.IMAGE,
         label_column_name=tlc.LABEL,
+        exclude_zero=False,
     ):
         # Populate self.samples with image paths and labels
         # Each is a tuple of (image_path, label)
@@ -46,6 +47,9 @@ class TLCClassificationDataset(TLCDatasetMixin, ClassificationDataset):
         self.example_ids = []
 
         for example_id, row in enumerate(self.table.table_rows):
+            if exclude_zero and row.get(tlc.SAMPLE_WEIGHT, 1) == 0:
+                continue
+
             self.example_ids.append(example_id)
             image_path = Path(tlc.Url(row[image_column_name]).to_absolute().to_str())
             self.samples.append((image_path, row[label_column_name]))

--- a/ultralytics/utils/tlc/classify/trainer.py
+++ b/ultralytics/utils/tlc/classify/trainer.py
@@ -31,6 +31,7 @@ class TLCClassificationTrainer(TLCTrainerMixin, yolo.classify.ClassificationTrai
         return self.data["train"], self.data.get("val") or self.data.get("test")
 
     def build_dataset(self, table, mode="train", batch=None):
+        exclude_zero = mode == "val" and self._settings.exclude_zero_weight_collection
         return TLCClassificationDataset(
             table,
             args=self.args,
@@ -38,6 +39,7 @@ class TLCClassificationTrainer(TLCTrainerMixin, yolo.classify.ClassificationTrai
             prefix=mode,
             image_column_name=self._image_column_name,
             label_column_name=self._label_column_name,
+            exclude_zero=exclude_zero,
         )
 
     def get_validator(self, dataloader=None):

--- a/ultralytics/utils/tlc/classify/validator.py
+++ b/ultralytics/utils/tlc/classify/validator.py
@@ -36,6 +36,7 @@ class TLCClassificationValidator(TLCValidatorMixin, yolo.classify.Classification
             prefix=self.args.split,
             image_column_name=self._image_column_name,
             label_column_name=self._label_column_name,
+            exclude_zero=self._settings.exclude_zero_weight_collection,
         )
 
     def _get_metrics_schemas(self):

--- a/ultralytics/utils/tlc/detect/trainer.py
+++ b/ultralytics/utils/tlc/detect/trainer.py
@@ -32,7 +32,17 @@ class TLCDetectionTrainer(TLCTrainerMixin, DetectionTrainer):
     def build_dataset(self, table, mode="train", batch=None):
         # Dataset object for training / validation
         gs = max(int(de_parallel(self.model).stride.max() if self.model else 0), 32)
-        return build_tlc_yolo_dataset(self.args, table, batch, self.data, mode=mode, rect=mode == "val", stride=gs)
+        exclude_zero = mode == "val" and self._settings.exclude_zero_weight_collection
+        return build_tlc_yolo_dataset(
+            self.args,
+            table,
+            batch,
+            self.data,
+            mode=mode,
+            rect=mode == "val",
+            stride=gs,
+            exclude_zero=exclude_zero,
+        )
 
     def get_validator(self, dataloader=None):
         self.loss_names = "box_loss", "cls_loss", "dfl_loss"

--- a/ultralytics/utils/tlc/detect/utils.py
+++ b/ultralytics/utils/tlc/detect/utils.py
@@ -65,12 +65,23 @@ def get_or_create_det_table(
                                description="Created with 3LC YOLOv8 integration")
 
 
-def build_tlc_yolo_dataset(cfg, table, batch, data, mode="train", rect=False, stride=32, multi_modal=False):
+def build_tlc_yolo_dataset(
+    cfg,
+    table,
+    batch,
+    data,
+    mode="train",
+    rect=False,
+    stride=32,
+    multi_modal=False,
+    exclude_zero=False,
+):
     if multi_modal:
         return ValueError("Multi-modal datasets are not supported in the 3LC YOLOv8 integration.")
 
     return TLCYOLODataset(
         table,
+        exclude_zero=exclude_zero,
         imgsz=cfg.imgsz,
         batch_size=batch,
         augment=mode == "train",  # augmentation

--- a/ultralytics/utils/tlc/detect/validator.py
+++ b/ultralytics/utils/tlc/detect/validator.py
@@ -29,7 +29,15 @@ class TLCDetectionValidator(TLCValidatorMixin, DetectionValidator):
         return build_dataloader(dataset, batch_size, self.args.workers, shuffle=False, rank=-1, sampler=sampler)
 
     def build_dataset(self, table, mode="val", batch=None):
-        return build_tlc_yolo_dataset(self.args, table, batch, self.data, mode=mode, stride=self.stride)
+        return build_tlc_yolo_dataset(
+            self.args,
+            table,
+            batch,
+            self.data,
+            mode=mode,
+            stride=self.stride,
+            exclude_zero=self._settings.exclude_zero_weight_collection,
+        )
 
     def _get_metrics_schemas(self):
         return {

--- a/ultralytics/utils/tlc/engine/dataset.py
+++ b/ultralytics/utils/tlc/engine/dataset.py
@@ -25,6 +25,9 @@ class TLCDatasetMixin:
         sample[tlc.EXAMPLE_ID] = self.example_ids[index]  # Add example id to the sample dict
         return sample
 
+    def __len__(self):
+        return len(self.example_ids)
+
     def _is_scanned(self):
         """ Check if the dataset has been scanned. """
         verified_marker_url = self.table.url / "cache.yolo"

--- a/ultralytics/utils/tlc/utils.py
+++ b/ultralytics/utils/tlc/utils.py
@@ -263,7 +263,6 @@ def create_sampler(table: tlc.Table,
         if distributed:
             raise NotImplementedError("Distributed validation and exclusion by weight is not yet supported.")
 
-        if settings.exclude_zero_weight_collection:
-            sampler = table.create_sampler(exclude_zero_weights=True, weighted=False, shuffle=False)
-
+        # Exclude zero weight is handled in the dataset
+        return None
     return sampler

--- a/ultralytics/utils/tlc/utils.py
+++ b/ultralytics/utils/tlc/utils.py
@@ -263,6 +263,6 @@ def create_sampler(table: tlc.Table,
         if distributed:
             raise NotImplementedError("Distributed validation and exclusion by weight is not yet supported.")
 
-        # Exclude zero weight is handled in the dataset
+        # Exclude zero weight is handled in the dataset for validation
         return None
     return sampler


### PR DESCRIPTION
Move handling of zero weight exclusion back to the dataset in collection/validation, in order to respect `rect=True` reordering.