### PR TITLE
Add predictor to allow model.predict()

### DIFF
--- a/tests/test_3lc.py
+++ b/tests/test_3lc.py
@@ -154,7 +154,7 @@ def test_classify_training() -> None:
     preds_3lc = model_3lc.predict(imgsz=320)
     preds_ultralytics = model_ultralytics.predict(imgsz=320)
 
-    assert all(preds_3lc[0].probs.top5 == preds_ultralytics[0].probs.top5), "Predictions mismatch"
+    assert preds_3lc[0].probs.top5 == preds_ultralytics[0].probs.top5, "Predictions mismatch"
 
 
 @pytest.mark.parametrize("task", ["detect"])

--- a/tests/test_3lc.py
+++ b/tests/test_3lc.py
@@ -85,6 +85,10 @@ def test_detect_training() -> None:
     assert 0 in metrics_df["Training Phase"], "Expected metrics from during training"
     assert 1 in metrics_df["Training Phase"], "Expected metrics from after training"
 
+    # model.predict() should work and be the same as vanilla ultralytics
+    assert all(model_ultralytics.predict(imgsz=320)[0].boxes.cls == model_3lc.predict(
+        imgsz=320)[0].boxes.cls), "Predictions mismatch"
+
 
 def test_classify_training() -> None:
     model = TASK2MODEL["classify"]
@@ -145,6 +149,12 @@ def test_classify_training() -> None:
 
     assert results_dict[
         "val"].results_dict == results_ultralytics.results_dict, "Results validation metrics collection onlywith  3LC different from Ultralytics"
+
+    # model.predict() should work and be the same as vanilla ultralytics
+    preds_3lc = model_3lc.predict(imgsz=320)
+    preds_ultralytics = model_ultralytics.predict(imgsz=320)
+
+    assert all(preds_3lc[0].probs.top5 == preds_ultralytics[0].probs.top5), "Predictions mismatch"
 
 
 @pytest.mark.parametrize("task", ["detect"])

--- a/ultralytics/utils/tlc/engine/model.py
+++ b/ultralytics/utils/tlc/engine/model.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import tlc
 
+from ultralytics.models import yolo
 from ultralytics.models.yolo.model import YOLO
 
 from ultralytics.nn.tasks import ClassificationModel, DetectionModel
@@ -32,11 +33,13 @@ class TLCYOLO(YOLO):
             "detect": {
                 "model": DetectionModel,
                 "trainer": TLCDetectionTrainer,
-                "validator": TLCDetectionValidator, },
+                "validator": TLCDetectionValidator,
+                "predictor": yolo.detect.DetectionPredictor, },
             "classify": {
                 "model": ClassificationModel,
                 "trainer": TLCClassificationTrainer,
-                "validator": TLCClassificationValidator, }, }
+                "validator": TLCClassificationValidator,
+                "predictor": yolo.classify.ClassificationPredictor, }, }
 
     def collect(self,
                 data: str | None = None,


### PR DESCRIPTION
Add predictors to `TLCYOLO` such that `model.predict()` can be called. This will not create or consume any 3LC objects for now.