### PR TITLE
Set run status running on TrainerMixin init

### DIFF
--- a/ultralytics/utils/tlc/engine/trainer.py
+++ b/ultralytics/utils/tlc/engine/trainer.py
@@ -51,7 +51,7 @@ class TLCTrainerMixin(BaseTrainer):
 
             # Log parameters to 3LC
             self._log_3lc_parameters()
-
+            self._run.set_status_running()
             self._print_metrics_collection_epochs()
 
     def _log_3lc_parameters(self):


### PR DESCRIPTION
If no metrics collection was ever performed, the run would be stuck in status empty until program termination.