### PR TITLE
Only get required tables from yolo yaml

### DIFF
--- a/tests/test_3lc.py
+++ b/tests/test_3lc.py
@@ -377,7 +377,7 @@ def test_exclude_zero_weight_collection(task, trainer_class) -> None:
     settings = Settings(project_name=f"test_sampling_weights_collection_{task}", exclude_zero_weight_collection=True)
     trainer = trainer_class(overrides={"data": TASK2DATASET[task], "settings": settings, "workers": 2})
 
-    # Classification trainer needs a model object to create dataloader
+    # Classification trainer needs a model attribute to create dataloader
     if task == "classify":
         trainer.model = Mock()
 

--- a/ultralytics/utils/tlc/classify/trainer.py
+++ b/ultralytics/utils/tlc/classify/trainer.py
@@ -27,7 +27,19 @@ class TLCClassificationTrainer(TLCTrainerMixin, yolo.classify.ClassificationTrai
             self._image_column_name,
             self._label_column_name,
             project_name=self._settings.project_name,
+            splits=("train", "val"),
         )
+        if "val" not in self.data:
+            data_test = tlc_check_cls_dataset(
+                self.args.data,
+                self._tables,
+                self._image_column_name,
+                self._label_column_name,
+                project_name=self._settings.project_name,
+                splits=("test", ),
+            )
+            self.data["test"] = data_test["test"]
+
         return self.data["train"], self.data.get("val") or self.data.get("test")
 
     def build_dataset(self, table, mode="train", batch=None):

--- a/ultralytics/utils/tlc/classify/utils.py
+++ b/ultralytics/utils/tlc/classify/utils.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from ultralytics.data.utils import IMG_FORMATS, check_cls_dataset
 from ultralytics.utils.tlc.utils import check_tlc_dataset
 
+from typing import Iterable
+
 
 def tlc_check_cls_dataset(
     data: str,
@@ -15,25 +17,30 @@ def tlc_check_cls_dataset(
     image_column_name: str,
     label_column_name: str,
     project_name: str | None = None,
+    splits: Iterable[str] | None = None,
 ) -> dict[str, tlc.Table | dict[float, str] | int]:
-    """ Get or create tables for YOLOv8 classification datasets. data is ignored when tables is provided.
-    
+    """Get or create tables for YOLOv8 classification datasets. data is ignored when tables is provided.
+
     :param data: Path to an ImageFolder dataset
     :param tables: Dictionary of tables, if already created
     :param image_column_name: Name of the column containing image paths
     :param label_column_name: Name of the column containing labels
     :param project_name: Name of the project
+    :param splits: List of splits to check for
     :return: Dictionary of tables and class names, with keys for each split and "names"
     """
-    return check_tlc_dataset(data,
-                             tables,
-                             image_column_name,
-                             label_column_name,
-                             dataset_checker=check_cls_dataset,
-                             table_creator=get_or_create_cls_table,
-                             table_checker=check_cls_table,
-                             project_name=project_name,
-                             check_backwards_compatible_table_name=False)
+    return check_tlc_dataset(
+        data,
+        tables,
+        image_column_name,
+        label_column_name,
+        dataset_checker=check_cls_dataset,
+        table_creator=get_or_create_cls_table,
+        table_checker=check_cls_table,
+        project_name=project_name,
+        check_backwards_compatible_table_name=False,
+        splits=splits,
+    )
 
 
 def get_or_create_cls_table(
@@ -45,8 +52,8 @@ def get_or_create_cls_table(
     dataset_name: str,
     table_name: str,
 ) -> tlc.Table:
-    """ Get or create a classification table from a dataset dictionary.
-    
+    """Get or create a classification table from a dataset dictionary.
+
     :param data_dict: Dictionary of dataset information
     :param project_name: Name of the project
     :param dataset_name: Name of the dataset
@@ -55,31 +62,38 @@ def get_or_create_cls_table(
     :param label_column_name: Name of the column containing labels
     :return: A tlc.Table.from_image_folder() table
     """
-    return tlc.Table.from_image_folder(root=data_dict[key],
-                                       image_column_name=image_column_name,
-                                       label_column_name=label_column_name,
-                                       project_name=project_name,
-                                       dataset_name=dataset_name,
-                                       table_name=table_name,
-                                       extensions=IMG_FORMATS,
-                                       if_exists="reuse",
-                                       add_weight_column=True,
-                                       description="Created with 3LC YOLOv8 integration")
+    return tlc.Table.from_image_folder(
+        root=data_dict[key],
+        image_column_name=image_column_name,
+        label_column_name=label_column_name,
+        project_name=project_name,
+        dataset_name=dataset_name,
+        table_name=table_name,
+        extensions=IMG_FORMATS,
+        if_exists="reuse",
+        add_weight_column=True,
+        description="Created with 3LC YOLOv8 integration",
+    )
 
 
 def check_cls_table(table: tlc.Table, image_column_name: str, label_column_name: str) -> None:
-    """ Check that a table is compatible with the current task."""
+    """Check that a table is compatible with the current task."""
     row_schema = table.row_schema.values
 
     try:
         # Check for image and label columns in schema
-        assert image_column_name in row_schema, f"Image column '{image_column_name}' not found in schema for Table {table.url}. Try providing your 'image_column_name' as an argument if you have a different column name."
-        assert label_column_name in row_schema, f"Label column '{label_column_name}' not found in schema for Table {table.url}. Try providing your 'label_column_name' as an argument if you have a different column name."
+        assert (
+            image_column_name in row_schema
+        ), f"Image column '{image_column_name}' not found in schema for Table {table.url}. Try providing your 'image_column_name' as an argument if you have a different column name."
+        assert (
+            label_column_name in row_schema
+        ), f"Label column '{label_column_name}' not found in schema for Table {table.url}. Try providing your 'label_column_name' as an argument if you have a different column name."
 
         # Check for desired roles
-        assert row_schema[
-            image_column_name].value.string_role == tlc.STRING_ROLE_IMAGE_URL, f"Image column '{image_column_name}' must have role tlc.STRING_ROLE_IMAGE_URL={tlc.STRING_ROLE_IMAGE_URL}."
-        assert row_schema[
-            label_column_name].value.number_role == tlc.LABEL, f"Label column '{label_column_name}' must have role tlc.LABEL={tlc.LABEL}."
+        assert (
+            row_schema[image_column_name].value.string_role == tlc.STRING_ROLE_IMAGE_URL
+        ), f"Image column '{image_column_name}' must have role tlc.STRING_ROLE_IMAGE_URL={tlc.STRING_ROLE_IMAGE_URL}."
+        assert (row_schema[label_column_name].value.number_role == tlc.LABEL
+                ), f"Label column '{label_column_name}' must have role tlc.LABEL={tlc.LABEL}."
     except AssertionError as e:
         raise ValueError(f"Table {table.url} is not compatible with YOLOv8 classification.") from e

--- a/ultralytics/utils/tlc/detect/trainer.py
+++ b/ultralytics/utils/tlc/detect/trainer.py
@@ -26,7 +26,21 @@ class TLCDetectionTrainer(TLCTrainerMixin, DetectionTrainer):
             self._image_column_name,
             self._label_column_name,
             project_name=self._settings.project_name,
+            splits=("train", "val"),
         )
+
+        # Get test data if val not present
+        if "val" not in self.data:
+            data_test = tlc_check_det_dataset(
+                self.args.data,
+                self._tables,
+                self._image_column_name,
+                self._label_column_name,
+                project_name=self._settings.project_name,
+                splits=("test", ),
+            )
+            self.data["test"] = data_test["test"]
+
         return self.data["train"], self.data.get("val") or self.data.get("test")
 
     def build_dataset(self, table, mode="train", batch=None):

--- a/ultralytics/utils/tlc/detect/utils.py
+++ b/ultralytics/utils/tlc/detect/utils.py
@@ -14,6 +14,8 @@ from ultralytics.utils import colorstr
 from ultralytics.utils.tlc.detect.dataset import TLCYOLODataset
 from ultralytics.utils.tlc.utils import check_tlc_dataset
 
+from typing import Iterable
+
 
 def tlc_check_det_dataset(
     data: str,
@@ -21,6 +23,7 @@ def tlc_check_det_dataset(
     image_column_name: str,
     label_column_name: str,
     project_name: str | None = None,
+    splits: Iterable[str] | None = None,
 ) -> dict[str, tlc.Table | dict[float, str] | int]:
     return check_tlc_dataset(
         data,
@@ -32,6 +35,7 @@ def tlc_check_det_dataset(
         table_checker=check_det_table,
         project_name=project_name,
         check_backwards_compatible_table_name=True,
+        splits=splits,
     )
 
 
@@ -44,8 +48,9 @@ def get_or_create_det_table(
     dataset_name: str,
     table_name: str,
 ) -> tlc.Table:
-    """ Get or create a detection table from a dataset dictionary.
+    """Get or create a detection table from a dataset dictionary.
 
+    :param key: The key of the dataset dictionary (the split to use)
     :param data_dict: Dictionary of dataset information
     :param project_name: Name of the project
     :param dataset_name: Name of the dataset
@@ -54,15 +59,17 @@ def get_or_create_det_table(
     :param label_column_name: Name of the column containing labels
     :return: A tlc.Table.from_yolo() table
     """
-    return tlc.Table.from_yolo(dataset_yaml_file=data_dict["yaml_file"],
-                               split=key,
-                               override_split_path=data_dict[key],
-                               project_name=project_name,
-                               dataset_name=dataset_name,
-                               table_name=table_name,
-                               if_exists="reuse",
-                               add_weight_column=True,
-                               description="Created with 3LC YOLOv8 integration")
+    return tlc.Table.from_yolo(
+        dataset_yaml_file=data_dict["yaml_file"],
+        split=key,
+        override_split_path=data_dict[key],
+        project_name=project_name,
+        dataset_name=dataset_name,
+        table_name=table_name,
+        if_exists="reuse",
+        add_weight_column=True,
+        description="Created with 3LC YOLOv8 integration",
+    )
 
 
 def build_tlc_yolo_dataset(
@@ -76,9 +83,10 @@ def build_tlc_yolo_dataset(
     multi_modal=False,
     exclude_zero=False,
     class_map=None,
+    split=None,
 ):
     if multi_modal:
-        return ValueError("Multi-modal datasets are not supported in the 3LC YOLOv8 integration.")
+        return ValueError("Multi-modal datasets are not supported in the 3LC Ultralytics integration.")
 
     return TLCYOLODataset(
         table,
@@ -93,7 +101,7 @@ def build_tlc_yolo_dataset(
         single_cls=cfg.single_cls or False,
         stride=int(stride),
         pad=0.0 if mode == "train" else 0.5,
-        prefix=colorstr(f"{mode}: "),
+        prefix=cfg.split if hasattr(cfg, "split") else mode,
         task=cfg.task,
         classes=cfg.classes,
         data=data,
@@ -102,19 +110,19 @@ def build_tlc_yolo_dataset(
 
 
 def check_det_table(table: tlc.Table, _0: str, _1: str) -> None:
-    """ Check that a table is compatible with the detection task in the 3LC YOLOv8 integration.
-    
+    """Check that a table is compatible with the detection task in the 3LC YOLOv8 integration.
+
     :param split: The split of the table.
     :param table: The table to check.
     :raises: ValueError if the table is not compatible with the detection task.
     """
     if not (is_yolo_table(table) or is_coco_table(table)):
         raise ValueError(
-            f'Table {table.url} is not compatible with YOLOv8 object detection, needs to be a YOLO or COCO table.')
+            f"Table {table.url} is not compatible with YOLOv8 object detection, needs to be a YOLO or COCO table.")
 
 
 def yolo_predicted_bounding_box_schema(categories: dict[int, str]) -> tlc.Schema:
-    """ Create a 3LC bounding box schema for YOLOv8
+    """Create a 3LC bounding box schema for YOLOv8
 
     :param categories: Categories for the current dataset.
     :returns: The YOLO bounding box schema for predicted boxes.
@@ -131,7 +139,7 @@ def yolo_predicted_bounding_box_schema(categories: dict[int, str]) -> tlc.Schema
         y0_unit=tlc.UNIT_RELATIVE,
         x1_unit=tlc.UNIT_RELATIVE,
         y1_unit=tlc.UNIT_RELATIVE,
-        description='Predicted Bounding Boxes',
+        description="Predicted Bounding Boxes",
         writable=False,
         is_prediction=True,
         include_segmentation=False,
@@ -141,29 +149,31 @@ def yolo_predicted_bounding_box_schema(categories: dict[int, str]) -> tlc.Schema
 
 
 def yolo_loss_schemas(training: bool = False) -> dict[str, tlc.Schema]:
-    """ Create a 3LC schema for YOLOv8 per-sample loss metrics.
+    """Create a 3LC schema for YOLOv8 per-sample loss metrics.
 
     :param training: Whether metrics are collected during training.
     :returns: The YOLO loss schemas for each of the three components.
     """
     schemas = {}
-    schemas['box_loss'] = tlc.Schema(description='Box Loss',
+    schemas["box_loss"] = tlc.Schema(description="Box Loss",
                                      writable=False,
                                      value=tlc.Float32Value(),
                                      display_importance=3004)
-    schemas['dfl_loss'] = tlc.Schema(description='Distribution Focal Loss',
+    schemas["dfl_loss"] = tlc.Schema(description="Distribution Focal Loss",
                                      writable=False,
                                      value=tlc.Float32Value(),
                                      display_importance=3005)
-    schemas['cls_loss'] = tlc.Schema(description='Classification Loss',
+    schemas["cls_loss"] = tlc.Schema(description="Classification Loss",
                                      writable=False,
                                      value=tlc.Float32Value(),
                                      display_importance=3006)
     if training:
-        schemas['loss'] = tlc.Schema(description='Weighted sum of box, DFL, and classification losses used in training',
-                                     writable=False,
-                                     value=tlc.Float32Value(),
-                                     display_importance=3007)
+        schemas["loss"] = tlc.Schema(
+            description="Weighted sum of box, DFL, and classification losses used in training",
+            writable=False,
+            value=tlc.Float32Value(),
+            display_importance=3007,
+        )
     return schemas
 
 
@@ -188,9 +198,9 @@ def construct_bbox_struct(
     )
 
     for pred in predicted_annotations:
-        bbox, label, score, iou = pred['bbox'], pred['category_id'], pred['score'], pred['iou']
+        bbox, label, score, iou = pred["bbox"], pred["category_id"], pred["score"], pred["iou"]
         label_val = inverse_label_mapping[label] if inverse_label_mapping is not None else label
-        bbox_struct['bb_list'].append(
+        bbox_struct["bb_list"].append(
             _TLCPredictedBoundingBox(
                 label=label_val,
                 confidence=score,

--- a/ultralytics/utils/tlc/engine/validator.py
+++ b/ultralytics/utils/tlc/engine/validator.py
@@ -23,6 +23,7 @@ from ultralytics.utils.tlc.utils import image_embeddings_schema, training_phase_
 
 
 def execute_when_collecting(method):
+
     def wrapper(self, *args, **kwargs):
         if self._should_collect:
             return method(self, *args, **kwargs)
@@ -31,6 +32,7 @@ def execute_when_collecting(method):
 
 
 class TLCValidatorMixin(BaseValidator):
+
     def __init__(
         self,
         dataloader=None,
@@ -79,6 +81,7 @@ class TLCValidatorMixin(BaseValidator):
                 self._image_column_name,
                 self._label_column_name,
                 project_name=self._settings.project_name,
+                splits=(self.args.split, ),
             )
 
         # Create a run if not provided
@@ -100,13 +103,11 @@ class TLCValidatorMixin(BaseValidator):
                 self._run = tlc.init(
                     project_name=project_name,
                     description=self._settings.run_description
-                    if self._settings.run_description
-                    else DEFAULT_COLLECT_RUN_DESCRIPTION,
+                    if self._settings.run_description else DEFAULT_COLLECT_RUN_DESCRIPTION,
                     run_name=self._settings.run_name,
                 )
                 LOGGER.info(
-                    f"{TLC_COLORSTR}Created run named '{self._run.url.parts[-1]}' in project {self._run.project_name}."
-                )
+                    f"{TLC_COLORSTR}Created run named '{self._run.url.parts[-1]}' in project {self._run.project_name}.")
 
         self.metrics.run_url = self._run.url
 
@@ -114,9 +115,8 @@ class TLCValidatorMixin(BaseValidator):
         self._epoch = trainer.epoch if trainer is not None else self._epoch
 
         if trainer:
-            self._should_collect = (
-                not self._settings.collection_disable and self._epoch + 1 in trainer._metrics_collection_epochs
-            )
+            self._should_collect = (not self._settings.collection_disable
+                                    and self._epoch + 1 in trainer._metrics_collection_epochs)
         else:
             self._should_collect = not self._settings.collection_disable
 
@@ -136,7 +136,7 @@ class TLCValidatorMixin(BaseValidator):
         initial_spaces = len(desc) - len(desc.lstrip())
         split_centered = split.center(initial_spaces)
         split_str = f"{colorstr(split_centered)}"
-        desc = split_str + desc[len(split_centered) :]
+        desc = split_str + desc[len(split_centered):]
 
         return desc
 
@@ -269,24 +269,16 @@ class TLCValidatorMixin(BaseValidator):
         training_phase = 1 if self._final_validation else 0
         num_classes = self.nc + 1  # all classes plus "all"
 
-        metrics_batch = (
-            {
-                tlc.EPOCH: [epoch] * num_classes,
-                TRAINING_PHASE: [training_phase] * num_classes,
-            }
-            if self._training
-            else {}
-        )
+        metrics_batch = ({
+            tlc.EPOCH: [epoch] * num_classes,
+            TRAINING_PHASE: [training_phase] * num_classes, } if self._training else {})
 
-        metrics_batch.update(
-            {
-                tlc.FOREIGN_TABLE_ID: [0] * num_classes,
-                tlc.LABEL: list(range(num_classes)),
-                NUM_INSTANCES: np.append(self.nt_per_class, self.nt_per_class.sum()),
-                NUM_IMAGES: np.append(self.nt_per_image, self.seen),
-                **self._generate_per_class_metrics(),
-            }
-        )
+        metrics_batch.update({
+            tlc.FOREIGN_TABLE_ID: [0] * num_classes,
+            tlc.LABEL: list(range(num_classes)),
+            NUM_INSTANCES: np.append(self.nt_per_class, self.nt_per_class.sum()),
+            NUM_IMAGES: np.append(self.nt_per_image, self.seen),
+            **self._generate_per_class_metrics(), })
 
         metrics_writer.add_batch(metrics_batch)
         metrics_writer.finalize()
@@ -299,34 +291,43 @@ class TLCValidatorMixin(BaseValidator):
 
     def _per_class_metrics_schemas(self):
         return {
-            TRAINING_PHASE: training_phase_schema(),
-            tlc.FOREIGN_TABLE_ID: tlc.ForeignTableIdSchema(self.dataloader.dataset.table.url.to_str()),
-            tlc.LABEL: tlc.CategoricalLabel("class", {**self.names, self.nc: "all"}).schema,
-            NUM_IMAGES: tlc.Schema(
+            TRAINING_PHASE:
+            training_phase_schema(),
+            tlc.FOREIGN_TABLE_ID:
+            tlc.ForeignTableIdSchema(self.dataloader.dataset.table.url.to_str()),
+            tlc.LABEL:
+            tlc.CategoricalLabel("class", {
+                **self.names, self.nc: "all"}).schema,
+            NUM_IMAGES:
+            tlc.Schema(
                 value=tlc.Int32Value(),
                 description="Number of images with at least one instance of the class",
             ),
-            NUM_INSTANCES: tlc.Schema(
+            NUM_INSTANCES:
+            tlc.Schema(
                 value=tlc.Int32Value(),
                 description="Total number of instances of the class in all images",
             ),
-            PRECISION: tlc.Schema(
+            PRECISION:
+            tlc.Schema(
                 value=tlc.Float32Value(),
                 description="Precision of the class",
             ),
-            RECALL: tlc.Schema(
+            RECALL:
+            tlc.Schema(
                 value=tlc.Float32Value(),
                 description="Recall of the class",
             ),
-            MAP: tlc.Schema(
+            MAP:
+            tlc.Schema(
                 value=tlc.Float32Value(),
                 description="mAP of the class",
             ),
-            MAP50_95: tlc.Schema(
+            MAP50_95:
+            tlc.Schema(
                 value=tlc.Float32Value(),
                 description="mAP50-95 of the class",
-            ),
-        }
+            ), }
 
     def _generate_per_class_metrics(self):
         """Transform metrics from self.metrics to a format suitable for 3LC"""
@@ -358,8 +359,7 @@ class TLCValidatorMixin(BaseValidator):
             PRECISION: precisions,
             RECALL: recalls,
             MAP: mAPs,
-            MAP50_95: mAP50_95s,
-        }
+            MAP50_95: mAP50_95s, }
 
     def _verify_model_data_compatibility(self, model_class_names):
         """Verify that the model classes match the dataset classes. For a classification model, this amounts to checking

--- a/ultralytics/utils/tlc/utils.py
+++ b/ultralytics/utils/tlc/utils.py
@@ -44,8 +44,9 @@ def check_tlc_dataset(
     :return: Dictionary of tables and class names
     """
     # If the data starts with the 3LC prefix, parse the YAML file and populate `tables`
-    has_prefix = data.startswith(TLC_PREFIX)
-    if tables is None and has_prefix:
+    has_prefix = False
+    if tables is None and data.startswith(TLC_PREFIX):
+        has_prefix = True
         LOGGER.info(f"{TLC_COLORSTR}Parsing 3LC YAML file data={data} and populating tables")
         tables = parse_3lc_yaml_file(data)
 
@@ -55,8 +56,6 @@ def check_tlc_dataset(
         data_dict = dataset_checker(data)
 
         # Get or create tables
-        # LOGGER.info(f"{TLC_COLORSTR}Creating or reusing tables from data={data}")
-
         splits = splits or ("train", "val", "test", "minival")
 
         for key in splits:


### PR DESCRIPTION
When reading in a dataset from a yolo yaml file, only get or create tables that are required (e.g. don't make a test table during training if train and val splits are available).