### PR TITLE
Fail gracefully when aliases fail to expand

### DIFF
--- a/tests/test_3lc.py
+++ b/tests/test_3lc.py
@@ -11,6 +11,7 @@ from ultralytics.utils.tlc.classify.utils import tlc_check_cls_dataset
 from ultralytics.utils.tlc.detect.utils import tlc_check_det_dataset
 from ultralytics.utils.tlc.utils import check_tlc_dataset
 from ultralytics.models.yolo import YOLO
+from ultralytics.utils.tlc.engine.dataset import TLCDatasetMixin
 
 from tests import TMP
 from ultralytics.utils.tlc.constants import (
@@ -598,6 +599,10 @@ def test_check_tlc_dataset_bad_url() -> None:
     with pytest.raises(ValueError):
         check_tlc_dataset(data="", tables=tables, image_column_name="a", label_column_name="b")
 
+def test_absolutize_image_url() -> None:
+    url = tlc.Url("<UNEXPANDED_ALIAS>/in/my/url.png")
+    with pytest.raises(ValueError):
+        TLCDatasetMixin._absolutize_image_url(url, tlc.Url("some_table_url"))
 
 # HELPERS
 def _get_run_from_settings(settings: Settings) -> tlc.Run:

--- a/ultralytics/utils/tlc/classify/dataset.py
+++ b/ultralytics/utils/tlc/classify/dataset.py
@@ -53,7 +53,7 @@ class TLCClassificationDataset(TLCDatasetMixin, ClassificationDataset):
 
             self.example_ids.append(example_id)
             image_path = Path(
-                tlc.Url(row[image_column_name]).to_absolute(table.url).to_str()
+                self._absolutize_image_url(row[image_column_name], self.table.url)
             )
             category = (
                 class_map[row[label_column_name]]

--- a/ultralytics/utils/tlc/detect/dataset.py
+++ b/ultralytics/utils/tlc/detect/dataset.py
@@ -66,7 +66,7 @@ class TLCYOLODataset(TLCDatasetMixin, YOLODataset):
 
             self.example_ids.append(example_id)
 
-            im_file = tlc.Url(row[tlc.IMAGE]).to_absolute(self.table.url).to_str()
+            im_file = self._absolutize_image_url(row[tlc.IMAGE], self.table.url)
             self.im_files.append(im_file)
             self.labels.append(
                 tlc_table_row_to_yolo_label(

--- a/ultralytics/utils/tlc/engine/dataset.py
+++ b/ultralytics/utils/tlc/engine/dataset.py
@@ -30,6 +30,26 @@ class TLCDatasetMixin:
     def __len__(self):
         return len(self.example_ids)
 
+    @staticmethod
+    def _absolutize_image_url(image_str: str, table_url: tlc.Url) -> str:
+        """Expand aliases in the raw image string and absolutize the URL if it is relative.
+
+        Raise a ValueError if the alias cannot be expanded.
+
+        :param image_str: The raw image string to absolutize.
+        :return: The absolutized image string.
+        :raises ValueError: If the alias cannot be expanded.
+        """
+        url = tlc.Url(image_str)
+        try:
+            url = url.expand_aliases(allow_unexpanded=False)
+        except ValueError as e:
+            raise ValueError(
+                f"Failed to expand alias in image_str: {image_str}. Make sure the alias is spelled correctly and is registered in your configuration."
+            ) from e
+
+        return url.to_absolute(table_url).to_str()
+
     def _is_scanned(self):
         """Check if the dataset has been scanned."""
         verified_marker_url = self.table.url / "cache.yolo"


### PR DESCRIPTION
Instead of populating the dataset with invalid image paths, fail gracefully when aliases fail to expand during data preparation.