### PR TITLE
Add metrics collection function to Settings and update validator

### DIFF
--- a/ultralytics/utils/tlc/detect/utils.py
+++ b/ultralytics/utils/tlc/detect/utils.py
@@ -12,7 +12,6 @@ from tlc.client.torch.metrics.metrics_collectors.bounding_box_metrics_collector 
 from ultralytics.data.utils import check_det_dataset
 from ultralytics.utils.tlc.detect.dataset import TLCYOLODataset
 from ultralytics.utils.tlc.utils import check_tlc_dataset
-from ultralytics.utils import LOGGER
 
 from typing import Iterable
 

--- a/ultralytics/utils/tlc/detect/validator.py
+++ b/ultralytics/utils/tlc/detect/validator.py
@@ -1,7 +1,6 @@
 # Ultralytics YOLO 🚀, 3LC Integration, AGPL-3.0 license
 from __future__ import annotations
 
-import numpy as np
 import tlc
 import torch
 import weakref

--- a/ultralytics/utils/tlc/engine/validator.py
+++ b/ultralytics/utils/tlc/engine/validator.py
@@ -211,6 +211,9 @@ class TLCValidatorMixin(BaseValidator):
             **self._compute_3lc_metrics(preds, batch),  # Task specific metrics
         }
 
+        if self._settings.metrics_collection_function:
+            batch_metrics.update(self._settings.metrics_collection_function(preds, batch))
+
         if self._settings.image_embeddings_dim > 0:
             batch_metrics["embeddings"] = self.embeddings
 

--- a/ultralytics/utils/tlc/engine/validator.py
+++ b/ultralytics/utils/tlc/engine/validator.py
@@ -212,7 +212,9 @@ class TLCValidatorMixin(BaseValidator):
         }
 
         if self._settings.metrics_collection_function:
-            batch_metrics.update(self._settings.metrics_collection_function(preds, batch))
+            batch_metrics.update(
+                self._settings.metrics_collection_function(preds, batch)
+            )
 
         if self._settings.image_embeddings_dim > 0:
             batch_metrics["embeddings"] = self.embeddings

--- a/ultralytics/utils/tlc/engine/validator.py
+++ b/ultralytics/utils/tlc/engine/validator.py
@@ -233,6 +233,9 @@ class TLCValidatorMixin(BaseValidator):
             self._get_metrics_schemas()
         )  # Add task-specific metrics schema
 
+        if self._settings.metrics_schemas:
+            column_schemas.update(self._settings.metrics_schemas)
+
         self._prepare_loss_fn(model)
 
         if self._settings.image_embeddings_dim > 0:

--- a/ultralytics/utils/tlc/settings.py
+++ b/ultralytics/utils/tlc/settings.py
@@ -70,7 +70,9 @@ class Settings:
     collection_epoch_interval: int = field(default=1)
     """Epoch interval for collection. Only used if a starting epoch is set. Default: 1"""
 
-    metrics_collection_function: Callable[[Any, Any], dict[str, Any]] | None = field(default=None)
+    metrics_collection_function: Callable[[Any, Any], dict[str, Any]] | None = field(
+        default=None
+    )
     """Function to compute additional metrics during collection.
     
     This function should take predictions and batch data as arguments and return
@@ -92,7 +94,7 @@ class Settings:
         functions and ensure the function is defined at module level.
     
     Default: None"""
-    
+
     metrics_schemas: dict[str, tlc.Schema] | None = field(default=None)
     """Schemas for any additional metrics returned by the metrics_collection_function.
     
@@ -151,7 +153,7 @@ class Settings:
         )
         if self.image_embeddings_dim > 0:
             self._check_reducer_available()
-        
+
         # Validate metrics collection function if provided
         if self.metrics_collection_function is not None:
             assert callable(self.metrics_collection_function), (
@@ -305,9 +307,11 @@ class Settings:
 
         # Display defaults differently for environment variables as they are provided differently
         if self._from_env:
+
             def formatter(x):
                 return x if not isinstance(x, list) else ",".join(x)
         else:
+
             def formatter(x):
                 return x
 

--- a/ultralytics/utils/tlc/settings.py
+++ b/ultralytics/utils/tlc/settings.py
@@ -6,7 +6,7 @@ import os
 from dataclasses import dataclass, field, fields
 from difflib import get_close_matches
 from typing import Any, Callable
-
+import tlc
 
 from ultralytics.utils import LOGGER
 from ultralytics.utils.tlc.constants import TLC_COLORSTR
@@ -91,6 +91,12 @@ class Settings:
         This function must be pickleable if using multiprocessing. Avoid lambda
         functions and ensure the function is defined at module level.
     
+    Default: None"""
+    
+    metrics_schemas: dict[str, tlc.Schema] | None = field(default=None)
+    """Schemas for any additional metrics returned by the metrics_collection_function.
+    
+    Providing schemas is optional, but for complex metrics, it is recommended to provide a schema.
     Default: None"""
 
     @classmethod

--- a/ultralytics/utils/tlc/settings.py
+++ b/ultralytics/utils/tlc/settings.py
@@ -5,7 +5,8 @@ import importlib
 import os
 from dataclasses import dataclass, field, fields
 from difflib import get_close_matches
-from typing import Any
+from typing import Any, Callable
+
 
 from ultralytics.utils import LOGGER
 from ultralytics.utils.tlc.constants import TLC_COLORSTR
@@ -69,6 +70,29 @@ class Settings:
     collection_epoch_interval: int = field(default=1)
     """Epoch interval for collection. Only used if a starting epoch is set. Default: 1"""
 
+    metrics_collection_function: Callable[[Any, Any], dict[str, Any]] | None = field(default=None)
+    """Function to compute additional metrics during collection.
+    
+    This function should take predictions and batch data as arguments and return
+    a dictionary of additional metrics to be included in the collection.
+    
+    Args:
+        preds: Model predictions (format depends on task)
+        batch: Input batch data
+        
+    Returns:
+        Dictionary of additional metrics to collect
+        
+    Example:
+        def custom_metrics(preds, batch):
+            return {"custom_metric": compute_something(preds, batch)}
+    
+    Note:
+        This function must be pickleable if using multiprocessing. Avoid lambda
+        functions and ensure the function is defined at module level.
+    
+    Default: None"""
+
     @classmethod
     def from_env(cls) -> Settings:
         """Create a Settings instance from environment variables.
@@ -121,6 +145,12 @@ class Settings:
         )
         if self.image_embeddings_dim > 0:
             self._check_reducer_available()
+        
+        # Validate metrics collection function if provided
+        if self.metrics_collection_function is not None:
+            assert callable(self.metrics_collection_function), (
+                f"metrics_collection_function must be callable, got {type(self.metrics_collection_function)}"
+            )
 
         # Train / collect specific settings
         self._verify_training() if training else self._verify_collection()

--- a/ultralytics/utils/tlc/settings.py
+++ b/ultralytics/utils/tlc/settings.py
@@ -299,9 +299,11 @@ class Settings:
 
         # Display defaults differently for environment variables as they are provided differently
         if self._from_env:
-            formatter = lambda x: x if not isinstance(x, list) else ",".join(x)
+            def formatter(x):
+                return x if not isinstance(x, list) else ",".join(x)
         else:
-            formatter = lambda x: x
+            def formatter(x):
+                return x
 
         field_info_list = [
             {


### PR DESCRIPTION
- Introduced a new `metrics_collection_function` attribute in the `Settings` class to allow users to define a custom function for collecting additional metrics during training or collection.
- Updated the `TLCValidatorMixin` to utilize the `metrics_collection_function`, enabling the integration of custom metrics into the batch metrics during validation.